### PR TITLE
feat: Increase maximum results for Google Calendar events retrieval

### DIFF
--- a/src/app/api/calendar/google/route.ts
+++ b/src/app/api/calendar/google/route.ts
@@ -476,6 +476,7 @@ export async function PUT(request: NextRequest) {
       timeMax: newDateFromYMD(newDate().getFullYear() + 1, 0, 1).toISOString(),
       singleEvents: true,
       orderBy: "startTime",
+      maxResults: 2000,
     });
 
     //events sorted by master events first


### PR DESCRIPTION
- Updated the PUT request to set maxResults to 2000, allowing for more events to be fetched in a single API call.